### PR TITLE
Fix for missing payload for POST requests.

### DIFF
--- a/src/DivideIQ.php
+++ b/src/DivideIQ.php
@@ -175,6 +175,7 @@ class DivideIQ implements \JsonSerializable
             case 'POST':
                 $response = $this->client->post($path, [
                     'headers' => ['Authentication' => $this->accessToken->getToken()],
+                    'json' => $payload,
                 ]);
 
                 break;


### PR DESCRIPTION
When sending POST requests, the $payload argument of DivideIQ::request method was completely ignored, which results in, for example, impossibility to create a Stockbase order (`stockbase_orderrequest` service).

This simple PR completely fixes this problem. Putting the $payload variable contents into the `json` Guzzle option results in adding the json-encoded value into the request body. With this fix a was able to create orders just fine.